### PR TITLE
Re-export core crate under speciesnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+**/target
 .idea
 .DS_Store
 .env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,12 +261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,16 +672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,10 +699,10 @@ dependencies = [
  "font-kit",
  "image",
  "ort",
+ "ort-sys",
  "raqote",
  "show-image",
  "speciesnet",
- "speciesnet-core",
  "tracing",
  "tracing-subscriber",
 ]
@@ -769,6 +753,17 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "dlib"
@@ -891,12 +886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1001,15 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "freetype-sys"
@@ -1312,6 +1310,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "image"
 version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
 name = "litrs"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,23 +1894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12fcfa1bd49e0342ec1d07ed2be83b59963e7acbeb9310e1bb2c07b69dadd959"
 dependencies = [
  "jobserver",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2097,50 +2191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,15 +2219,15 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
+checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
 dependencies = [
  "flate2",
  "pkg-config",
  "sha2",
  "tar",
- "ureq",
+ "ureq 2.12.1",
 ]
 
 [[package]]
@@ -2254,15 +2304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,6 +2363,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2747,15 +2797,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,29 +2819,6 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.9.1",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2997,7 +3015,7 @@ dependencies = [
  "speciesnet-ensemble",
  "thiserror 2.0.12",
  "tracing",
- "ureq",
+ "ureq 3.0.12",
  "zip",
 ]
 
@@ -3011,6 +3029,7 @@ dependencies = [
  "ndarray",
  "num_cpus",
  "ort",
+ "ort-sys",
  "serde",
  "serde_json",
  "speciesnet-core",
@@ -3024,10 +3043,10 @@ dependencies = [
  "anyhow",
  "clap",
  "ort",
+ "ort-sys",
  "serde",
  "serde_json",
  "speciesnet",
- "speciesnet-core",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -3055,6 +3074,7 @@ dependencies = [
  "ndarray",
  "num_cpus",
  "ort",
+ "ort-sys",
  "speciesnet-core",
  "thiserror 2.0.12",
  "tracing",
@@ -3082,6 +3102,12 @@ dependencies = [
  "bitflags 1.3.2",
  "num-traits",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -3136,6 +3162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,19 +3201,6 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
-name = "tempfile"
-version = "3.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
-dependencies = [
- "fastrand",
- "getrandom 0.3.3",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "termcolor"
@@ -3289,6 +3313,16 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -3427,23 +3461,35 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
 version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
 dependencies = [
  "base64",
- "der",
  "flate2",
  "log",
- "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "socks",
  "ureq-proto",
  "utf-8",
- "webpki-root-certs 0.26.11",
  "webpki-roots 0.26.11",
 ]
 
@@ -3460,10 +3506,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3492,12 +3555,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -3693,24 +3750,6 @@ checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.2",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -4241,6 +4280,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4285,6 +4330,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4305,6 +4374,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4318,6 +4408,39 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The [speciesnet](./speciesnet/) library can be installed to other crates for run
 
 ```bash
 cargo add --git https://github.com/zubalis/speciesnet-rust.git --path speciesnet
-cargo add --git https://github.com/zubalis/speciesnet-rust.git --path core
 cargo add ort@=2.0.0-rc.9 -F download-binaries
+cargo add ort-sys@=2.0.0-rc.9
 ```
 
 inside your rust program.

--- a/classifier/Cargo.toml
+++ b/classifier/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 ort = { version = "=2.0.0-rc.9", default-features = false, features = ["ndarray", "copy-dylibs"] }
+ort-sys = "=2.0.0-rc.9"
 image = { workspace = true }
 ndarray = { workspace = true }
 num_cpus = { workspace = true }

--- a/detector/Cargo.toml
+++ b/detector/Cargo.toml
@@ -17,6 +17,7 @@ image = { workspace = true }
 ndarray = { workspace = true }
 num_cpus = { workspace = true } 
 ort = { version = "=2.0.0-rc.9", default-features = false, features = ["ndarray", "copy-dylibs"] }
+ort-sys = "=2.0.0-rc.9"
 speciesnet-core = { path = "../core" }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/examples/detect/Cargo.toml
+++ b/examples/detect/Cargo.toml
@@ -10,8 +10,8 @@ font-kit = "0.14"
 image = { workspace = true }
 raqote = { version = "0.8", default-features = false, features = ["text"] }
 ort = { version = "=2.0.0-rc.9", features = ["download-binaries"] }
+ort-sys = "=2.0.0-rc.9"
 show-image = { version = "=0.14.0", features = ["image", "raqote"] }
 speciesnet = { path = "../../speciesnet" }
-speciesnet-core = { path = "../../core" }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "ansi"] }

--- a/examples/detect/src/main.rs
+++ b/examples/detect/src/main.rs
@@ -6,8 +6,7 @@ use show_image::{
     AsImageView, WindowOptions,
     event::{VirtualKeyCode, WindowEvent},
 };
-use speciesnet::speciesnet::SpeciesNet;
-use speciesnet_core::{io::Instance, load_image};
+use speciesnet::{Instance, SpeciesNet, load_image};
 use tracing::info;
 use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt};
 

--- a/speciesnet-cli/Cargo.toml
+++ b/speciesnet-cli/Cargo.toml
@@ -17,9 +17,9 @@ readme = "README.md"
 anyhow = "1"
 clap = { version = "4.5", features = ["derive"] }
 ort = { version = "=2.0.0-rc.9", features = ["ndarray", "download-binaries"] }
+ort-sys = "=2.0.0-rc.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-speciesnet-core = { path = "../core" }
 speciesnet = { path = "../speciesnet" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "ansi"] }

--- a/speciesnet-cli/src/inputs.rs
+++ b/speciesnet-cli/src/inputs.rs
@@ -3,7 +3,7 @@ use std::{
     io::{BufRead, BufReader},
 };
 
-use speciesnet_core::io::{Instance, Instances};
+use speciesnet::{Instance, Instances};
 use tracing::{debug, info};
 use walkdir::WalkDir;
 
@@ -56,13 +56,12 @@ pub fn prepare_image_inputs(input_type: &InputType) -> anyhow::Result<Vec<Instan
 
         let joint_path_instances = instance_json_value.instances().iter().map(|instance| {
             let joint_image_path = instances_file_folder.join(instance.file_path());
-            let new_instance = Instance::new(
+
+            Instance::new(
                 joint_image_path,
                 instance.country().map(str::to_string),
                 instance.admin1_region().map(str::to_string),
-            );
-
-            new_instance
+            )
         });
 
         for instance in joint_path_instances {

--- a/speciesnet-cli/src/main.rs
+++ b/speciesnet-cli/src/main.rs
@@ -70,8 +70,7 @@ use std::{fs::File, io::BufWriter, path::PathBuf};
 
 use clap::{Args, CommandFactory, Parser, error::ErrorKind};
 use inputs::prepare_image_inputs;
-use speciesnet::SpeciesNet;
-use speciesnet_core::io::Predictions;
+use speciesnet::{Predictions, SpeciesNet};
 use tracing::info;
 use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt};
 

--- a/speciesnet/src/lib.rs
+++ b/speciesnet/src/lib.rs
@@ -38,7 +38,7 @@
 //!
 //! Running the entire pipeline (detector + classifier + ensemble).
 //!
-//! ```rust
+//! ```rust,no_run
 //! use std::path::PathBuf;
 //!
 //! use speciesnet::{SpeciesNet, Instance};
@@ -54,7 +54,7 @@
 //!
 //! Running the detector pipeline.
 //!
-//! ```rust
+//! ```rust,no_run
 //! use std::path::PathBuf;
 //!
 //! use speciesnet::{SpeciesNet, Instance};
@@ -73,7 +73,7 @@
 //!
 //! Running the classifier pipeline.
 //!  
-//! ```rust
+//! ```rust,no_run
 //! use std::path::PathBuf;
 //!
 //! use speciesnet::{SpeciesNet, Instance};
@@ -89,10 +89,10 @@
 //!
 //! Running the ensemble and geofence of the pipeline.
 //!
-//! NOTE: This function differs from other functions where it operates on each instance of
+//!  NOTE: This function differs from other functions where it operates on each instance of
 //! prediction, instead of taking the vector of predictions or instance like other API.
 //!
-//! ```rust
+//! ```rust,no_run
 //! use std::path::PathBuf;
 //!
 //! use speciesnet::{SpeciesNet, ClassificationBundle, BoundingBox, Category, Detection};
@@ -124,8 +124,8 @@ pub use speciesnet_core::{
     detector::{BoundingBox, Category, Detection},
     ensemble::GeofenceResult,
     io::{Instance, Instances, Prediction, Predictions},
-    shape::Shape,
     load_image,
+    shape::Shape,
 };
 
 pub use speciesnet::SpeciesNet;

--- a/speciesnet/src/lib.rs
+++ b/speciesnet/src/lib.rs
@@ -8,7 +8,6 @@
 //!
 //! ```bash
 //! cargo add --git https://github.com/zubalis/speciesnet-rust.git --path speciesnet
-//! cargo add --git https://github.com/zubalis/speciesnet-rust.git --path core
 //! cargo add ort@=2.0.0-rc.9 -F download-binaries
 //! ```
 //!
@@ -42,8 +41,7 @@
 //! ```rust
 //! use std::path::PathBuf;
 //!
-//! use speciesnet_core::io::Instance;
-//! use speciesnet::SpeciesNet;
+//! use speciesnet::{SpeciesNet, Instance};
 //!
 //! let instances = vec![
 //!     Instance::from_path_buf(PathBuf::from("./img1.jpeg")),
@@ -59,8 +57,7 @@
 //! ```rust
 //! use std::path::PathBuf;
 //!
-//! use speciesnet_core::io::Instance;
-//! use speciesnet::SpeciesNet;
+//! use speciesnet::{SpeciesNet, Instance};
 //!
 //! let instances = vec![
 //!     Instance::from_path_buf(PathBuf::from("./img1.jpeg")),
@@ -79,8 +76,7 @@
 //! ```rust
 //! use std::path::PathBuf;
 //!
-//! use speciesnet_core::io::Instance;
-//! use speciesnet::SpeciesNet;
+//! use speciesnet::{SpeciesNet, Instance};
 //!
 //! let instances = vec![
 //!     Instance::from_path_buf(PathBuf::from("./img1.jpeg")),
@@ -99,11 +95,7 @@
 //! ```rust
 //! use std::path::PathBuf;
 //!
-//! use speciesnet_core::{
-//!     classifier::ClassificationBundle,
-//!     detector::{BoundingBox, Category, Detection},
-//! };
-//! use speciesnet::SpeciesNet;
+//! use speciesnet::{SpeciesNet, ClassificationBundle, BoundingBox, Category, Detection};
 //!
 //! let instances_json_path = "./instances.json";
 //! let detector_file_path = "./output_detector.json";
@@ -126,5 +118,13 @@
 pub mod error;
 pub mod model_info;
 pub mod speciesnet;
+
+pub use speciesnet_core::{
+    classifier::{Classification, ClassificationBundle},
+    detector::{BoundingBox, Category, Detection},
+    ensemble::GeofenceResult,
+    io::{Instance, Instances, Prediction, Predictions},
+    shape::Shape,
+};
 
 pub use speciesnet::SpeciesNet;

--- a/speciesnet/src/lib.rs
+++ b/speciesnet/src/lib.rs
@@ -125,6 +125,7 @@ pub use speciesnet_core::{
     ensemble::GeofenceResult,
     io::{Instance, Instances, Prediction, Predictions},
     shape::Shape,
+    load_image,
 };
 
 pub use speciesnet::SpeciesNet;

--- a/speciesnet/src/model_info/download_model.rs
+++ b/speciesnet/src/model_info/download_model.rs
@@ -83,6 +83,8 @@ impl ModelInfo {
         let extract_dir = model_dir.join(DEFAULT_MODEL_FOLDER);
         zip_file.extract(&extract_dir)?;
 
+        // TODO: We might delete the zip file later on.
+
         ModelInfo::from_path(extract_dir)
     }
 }


### PR DESCRIPTION
fixes #45 and #46

Description
- Pin `ort-sys@=2.0.0-rc.9` as [it is not pinned](github.com/pykeio/ort/releases/tag/v2.0.0-rc.10)
- Bundle core into `speciesnet-rust`, no need for separate package installs.
- added a bunch of `no_run` tags for code examples.